### PR TITLE
Dark Souls: Add option to fix menu controls

### DIFF
--- a/Configs/01004AB00A260000.json
+++ b/Configs/01004AB00A260000.json
@@ -1560,6 +1560,24 @@
 					}
 				}
 			]
+		},
+		{
+			"saveFilePaths": [""],
+			"files": "lang",
+			"filetype": "bin",
+			"items": [
+				{
+					"name": "Fix menu controls (\uE0E0 Confirm/\uE0E1 Cancel)",
+					"category": "Controls",
+					"intArgs": [0, 2],
+					"strArgs": ["0000", "26"],
+					"widget": {
+						"type": "bool",
+						"onValue": 11050,
+						"offValue": 10795
+					}
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
Dark Souls has Confirm mapped to B and Cancel mapped to A (except in the Japanese version) and doesn't let you change it in-game.