### PR TITLE
Added Nyanko Daisensou cheat by robin5968

### DIFF
--- a/Configs/01003C300B274000.json
+++ b/Configs/01003C300B274000.json
@@ -1,0 +1,258 @@
+{
+	"author": "robin5968",
+	"scriptLanguage": "lua",
+	"beta": false,
+	"1.0.3": [
+		{
+			"saveFilePaths": [""],
+			"files": "savedata",
+			"filetype": "bin",
+			"items": [
+				{
+					"name": "Kanzume (Cat Can)",
+					"category": "General",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "002F"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999
+					}
+				},
+				{
+					"name": "XP",
+					"category": "General",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "0073"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99999999
+					}
+				},
+				{
+					"name": "Speed-up",
+					"category": "Items",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2D20"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "Treasure Radar",
+					"category": "Items",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2D24"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "Max Worker Rate",
+					"category": "Items",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2D28"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "Cat-Puter",
+					"category": "Items",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2D2C"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "XP-Up",
+					"category": "Items",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2D30"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "Sniper",
+					"category": "Items",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2D34"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "Silver Gatcha Ticket",
+					"category": "Gatcha Tickets",
+					"tooltip": "More than 999 will all display 999,\nbut the actual value is still modified.",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2F57"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "Gold Gatcha Ticket",
+					"category": "Gatcha Tickets",
+					"tooltip": "More than 999 will all display 999,\nbut the actual value is still modified.",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "2F5B"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999
+					}
+				},
+				{
+					"name": "Purple Matatabi Seed",
+					"category": "Matatabi Seeds",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36ACF"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Red Matatabi Seed",
+					"category": "Matatabi Seeds",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AD3"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Blue Matatabi Seed",
+					"category": "Matatabi Seeds",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AD7"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Green Matatabi Seed",
+					"category": "Matatabi Seeds",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36ADB"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Yellow Matatabi Seed",
+					"category": "Matatabi Seeds",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36ADF"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Purple Matatabi",
+					"category": "Matatabis",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AE3"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Red Matatabi",
+					"category": "Matatabis",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AE7"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Blue Matatabi",
+					"category": "Matatabis",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AEB"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Green Matatabi",
+					"category": "Matatabis",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AEF"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Yellow Matatabi",
+					"category": "Matatabis",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AF3"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Rainbow Matatabi",
+					"category": "Matatabis",
+					"tooltip": "All Matatabis can only have 256 in total,\nmore will be cutted off!",
+					"intArgs": [4, 4],
+					"strArgs": ["0000", "36AF7"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				}
+			]
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ You can PR your own research there if you have some but don't want to build a co
 | [Kirby Star Allies](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/01007E3006DDA000.json)           | kirbysa.py          | Ac_K | No |
 | [Romance of the Three Kingdoms 13 / Sangokushi 13](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/0100882001380000.json)           | bin.lua          | Abenx | Yes |
 | [SUPER DRAGON BALL HEROES WORLD MISSION](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/0100E5E00C464000.json) | DragonBallHeroes.py | Krank | No |
-| [Cadence of Hyrule](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/01000B900D8B0000.json | xml.py | DNA | Yes |
+| [Cadence of Hyrule](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/01000B900D8B0000.json) | xml.py | DNA | Yes |
 | [Gear Club Unlimited](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/010065E003FD8000.json)             | GearClubUnlimited.py | haykuro  | No |
+| [Futaride! Nyanko Daisensou / ふたりで! にゃんこ大戦争](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/01003C300B274000.json)           | bin.lua          | robin5968 | No |
 
 ## Editor Script files
 | Script                            | Requirements            | Author    | Beta   |


### PR DESCRIPTION
Added "Futaride! Nyanko Daisensou" (ふたりで! にゃんこ大戦争) cheat by robin5968.
It's mainly for XP, cans(Kanzume), tickets, Matatabis(Cat fruits), help items.
Not able to mod progress or characters yet (and no plan for those),
since realtime cheat of this game is broken now.
(btw, latest buildID is "b10b8d32ac84a135", not "83ed8627cb8a9801")

edited: also fixed Readme.md which missing ) issue by others :/