### PR TITLE
Implemented Save Editor for Paper Mario: The Origami King

### DIFF
--- a/Configs/0100A3900C3E2000.json
+++ b/Configs/0100A3900C3E2000.json
@@ -1,0 +1,589 @@
+{
+	"author": "proendreeper",
+	"scriptLanguage": "lua",
+	"beta": true,
+	"all": [
+		{
+			"saveFilePaths": [""],
+			"files": "data00\\.bin",
+			"filetype": "pmtok",
+			"items": [
+				{
+					"name": "Coins",
+					"category": "Player",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "coin"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999
+					}
+				},
+				{
+					"name": "Coins Spent",
+					"category": "Player",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "use_coin"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "HP",
+					"category": "Player",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "hp"],
+					"widget": {
+						"type": "int",
+						"minValue": 1,
+						"maxValue": 999
+					}
+				},
+				{
+					"name": "Max HP",
+					"category": "Player",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "hp_max"],
+					"widget": {
+						"type": "int",
+						"minValue": 1,
+						"maxValue": 999
+					}
+				},
+				{
+					"name": "Confetti",
+					"category": "Player",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "confetti_paper"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999999
+					}
+				},
+				{
+					"name": "Max Confetti",
+					"category": "Player",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "confetti_paper_max"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 9999999
+					}
+				},
+				{
+					"name": "Earth Bibliofold",
+					"category": "Progression",
+					"intArgs": [2],
+					"strArgs": ["Pouch", "equipment","magic","0"],
+					"widget": {
+						"type": "bool",
+						"onValue": "3:O_BOOK_EARTH",
+						"offValue": "-1:"
+					}
+				},
+				{
+					"name": "Water Bibliofold",
+					"category": "Progression",
+					"intArgs": [2],
+					"strArgs": ["Pouch", "equipment","magic","1"],
+					"widget": {
+						"type": "bool",
+						"onValue": "3:O_BOOK_WATER",
+						"offValue": "-1:"
+					}
+				},
+				{
+					"name": "Fire Bibliofold",
+					"category": "Progression",
+					"intArgs": [2],
+					"strArgs": ["Pouch", "equipment","magic","2"],
+					"widget": {
+						"type": "bool",
+						"onValue": "3:O_BOOK_FIRE",
+						"offValue": "-1:"
+					}
+				},
+				{
+					"name": "Ice Bibliofold",
+					"category": "Progression",
+					"intArgs": [2],
+					"strArgs": ["Pouch", "equipment","magic","3"],
+					"widget": {
+						"type": "bool",
+						"onValue": "3:O_BOOK_ICE",
+						"offValue": "-1:"
+					}
+				},
+				{
+					"name": "#RecordDisclaimer",
+					"category": "Records",
+					"intArgs": [ ],
+					"strArgs": [ ],
+					"widget": {
+						"type": "comment",
+						"comment": "It's unclear what most of these records do,\nthe names are based off the save file descriptors."
+					}
+				},
+				{
+					"name": "Toad Points",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "kinopio_point"],
+					"tooltip": "Seem to only update when you go to the museum.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999
+					}
+				},
+				{
+					"name": "Game Over Count",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch","record", "game_over_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999
+					}
+				},
+				{
+					"name": "Olivia Hint Count",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "olivia_hint_count"],
+					"widget": {
+						"type": "int",
+						"minValue": -999999999,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Photos Taken",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "take_photo_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "1-Up Mushrooms Used",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "use_1up_kinoko_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Total coins used at shop",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "shop_cumulative_coin"],
+					"tooltip": "How many coins have been used cumulatively at shops.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Total coins used to buy items",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "total_buy_item_coin"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Total coins used to buy accessories",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "total_buy_accessory_coin"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Battles Encountered",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "battle_encount_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Battle Puzzles Solved",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "puzzle_success_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Times Cheered",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "cheer_count"],
+					"tooltip": "How many times you've used toads to grant hearts/solve puzzles in battle.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Coins Cheered",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "total_cheer_coin"],
+					"tooltip": "How much you've used on toads to grant hearts/solve puzzles in battle.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Battle Time - Added Count",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "add_time_count"],
+					"tooltip": "How many times you've added time to solve a battle puzzle.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Battle Time - Coins Used",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "total_add_time_coin"],
+					"tooltip": "How many coins you've used to add time to solve a battle puzzle.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Footstep Count",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "footstep_count"],
+					"tooltip": "Unknown use.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Puzzle Level",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "puzzle_level"],
+					"tooltip": "Unknown use.",
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Open Offline Pages Count",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "open_offline_html"],
+					"widget": {
+						"type": "int",
+						"minValue": -999999999,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Battle Win Count",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "battle_win_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999
+					}
+				},
+				{
+					"name": "Battle Coins Won",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "battle_win_coin"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Battle Enemies Killed",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "battle_kill_enemy_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Battle EXP Won",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "battle_win_exP"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Total Coins Received",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "total_get_coin"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Total Excellent Count",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "total_excellent_count"],
+					"widget": {
+						"type": "int",
+						"minValue": 0,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Coin Adjust Rate",
+					"category": "Records",
+					"intArgs": [0],
+					"strArgs": ["Pouch", "record", "coin_adjust_rate"],
+					"widget": {
+						"type": "int",
+						"minValue": -999999999,
+						"maxValue": 999999999
+					}
+				},
+				{
+					"name": "Inventory Slot",
+					"dummy": true,
+					"category": "Inventory",
+					"intArgs": [0],
+					"strArgs": ["bag","item_slot"],
+					"widget":{
+						"type":"int",
+						"minValue": 1,
+						"maxValue": 150
+					}
+				},
+				{
+					"name": "Item Name",
+					"dummy": true,
+					"category": "Inventory",
+					"intArgs": [2],
+					"strArgs": ["bag","item_descriptor"],
+					"widget":{
+						"type":"list",
+						"listItemNames":["Hammer","Shiny Hammer","Flashy Hammer","Legendary Hammer","Gold Hammer","Hurlhammer","Flashy Hurlhammer","Fire Hammer","Ice Hammer","Boots","Shiny Boots","Flashy Boots","Legendary Boots","Gold Boots","Iron Boots","Shiny Iron Boots","Flashy Iron Boots","Legendary Iron Boots","Mushroom","Shiny Mushroom","Flashy Mushroom","1-Up Mushroom","Fire Flower","Shiny Fire Flower","Ice Flower","Shiny Ice Flower","Tail","Shiny Tail","POW Block","Guard Plus","Silver Guard Plus","Gold Guard Plus","Time Plus","Silver Time Plus","Gold Time Plus","Confetti Vacuum","Petal Bag","Membership Card","Silver Membership Card","Gold Membership Card","Heart Plus","Silver Heart Plus","Gold Heart Plus","Toad Alert","Treasure Alert","Hidden Block Alert","Toad Radar","Boot Whistle","Ally Tambourine","Lamination Suit","Coin Step Counter","Retro Soundbox","Hidden Block Unhider","Nothing"],
+						"listItemValues":["0:HAMMER","0:SILVER_HAMMER","0:SUPER_HAMMER","0:GREAT_HAMMER","0:GOLDEN_HAMMER","0:THROW_HAMMER","0:SUPER_THROW_HAMMER","0:FIRE_HAMMER","0:ICE_HAMMER","1:BOOTS","1:SILVER_BOOTS","1:SUPER_BOOTS","1:GREAT_BOOTS","1:GOLD_BOOTS","1:IRON_BOOTS","1:STEEL_BOOTS","1:SUPER_IRON_BOOTS","1:SUPER_STEEL_BOOTS","4:KINOKO","4:SUPER_KINOKO","4:GREAT_KINOKO","4:HEEL_KINOKO","4:FIRE_FLOWER","4:SUPER_FIRE_FLOWER","4:ICE_FLOWER","4:SUPER_ICE_FLOWER","4:TAIL","4:SUPER_TAIL","4:POW_BLOCK","2:PSV_Battle_DAMAGE1","2:PSV_Battle_DAMAGE2","2:PSV_Battle_DAMAGE3","2:PSV_Puzzle_TIME1","2:PSV_Puzzle_TIME2","2:PSV_Puzzle_TIME3","2:PSV_Sub_PaperVacuum","2:PSV_Sub_FlowerShower","2:PSV_Sub_MembersCard1","2:PSV_Sub_MembersCard2","2:PSV_Sub_MembersCard3","2:PSV_Battle_HP1","2:PSV_Battle_HP2","2:PSV_Battle_HP3","2:PSV_Sub_KinopioAlarm","2:PSV_Sub_TreasureAlarm","2:PSV_Sub_HideBlockAlarm","4:IC_KINOPIO_RS","4:IC_WHISTLE","2:PSV_Sub_BattleParty","4:IC_LATENCY","2:PSV_Sub_Pedometer","2:PSV_Sub_MarioSound","4:IC_SECRET_BLOCK_RS","-1:"]
+					}
+				},
+				{
+					"name": "Damage",
+					"dummy": true,
+					"category": "Inventory",
+					"intArgs": [0],
+					"strArgs": ["bag","item_damage"],
+					"widget":{
+						"type":"int",
+						"minValue": 0,
+						"maxValue": 999999
+					}
+				},
+				{
+					"name": "Durability",
+					"dummy": true,
+					"category": "Inventory",
+					"intArgs": [0],
+					"strArgs": ["bag","item_durability"],
+					"tooltip": "When damage reaches this number, the item breaks (maybe?)",
+					"widget":{
+						"type":"int",
+						"minValue": 0,
+						"maxValue": 999999
+					}
+				},
+				{
+					"name": "Item Count",
+					"dummy": true,
+					"category": "Inventory",
+					"intArgs": [0],
+					"strArgs": ["bag","item_count"],
+					"widget":{
+						"type":"int",
+						"minValue": 0,
+						"maxValue": 99
+					}
+				},
+				{
+					"name": "Key Item Slot",
+					"dummy": true,
+					"category": "Key Items",
+					"intArgs": [0],
+					"strArgs": ["bag","key_item_slot"],
+					"widget":{
+						"type":"int",
+						"minValue": 1,
+						"maxValue": 64
+					}
+				},
+				{
+					"name": "Stamp Card Notes",
+					"category": "Key Items",
+					"intArgs": [ ],
+					"strArgs": [ ],
+					"widget": {
+						"type": "comment",
+						"comment": "The letters in parenthesis denote which\nstamps have been received.\n\nR - Red\nG - Green\nM - Magenta\nB - Blue"
+					}
+				},
+				{
+					"name": "Item Name",
+					"dummy": true,
+					"category": "Key Items",
+					"intArgs": [0],
+					"strArgs": ["bag","key_item_name"],
+					"widget":{
+						"type":"list",
+						"listItemNames":["Nothing","Empty Stamp Card","Stamp Card (R)","Stamp Card (G)","Stamp Card (GR)","Stamp Card (M)","Stamp Card (MR)","Stamp Card (GM)","Stamp Card (GMR)","Stamp Card (B)","Stamp Card (BR)","Stamp Card (BG)","Stamp Card (BGR)","Stamp Card (BM)","Stamp Card (BMR)","Stamp Card (BGM)","Stamp Card (BGMR)","Key to Peach's Castle","Key to Bowser's Castle","Spring of Rainbows - VIP","Red Gem","Courage Orb","Wisdom Orb","Power Orb","Diamond Key","Big Shell","Mushroom Handle","Canned Heart","\"Thrills at Night\"","\"Heartbeat Skipper\"","\"Deep, Deep Vibes\"","\"M-A-X Power!\"","Round Jewel","Diamond Jewel","Square Jewel","Triangle Jewel","Suite Key","Shriveled MAX UP Heart","Sun Incense","Professor's Room Key","Lever","Shogun Studios Master Key","Bone","Baseball","Space Warrior Mask","Jungle King Mask","Goomba Mask","Shuriken","Straw","Commoner Pass","Royalty Pass","Opened Can of Tuna","Canned Tuna","Groovier Panel","Groovy Panel","Blue Shell Stone","Red Shell Stone","Yellow Shell Stone","Green Shell Stone","Manhole Hook","Soul Seed","Shriveled Seed","Faded Fire Flower","Shriveled Mushroom"],
+						"listItemValues":["","X_STAMPCARD_A","X_STAMPCARD_B","X_STAMPCARD_C","X_STAMPCARD_D","X_STAMPCARD_E","X_STAMPCARD_F","X_STAMPCARD_G","X_STAMPCARD_H","X_STAMPCARD_I","X_STAMPCARD_J","X_STAMPCARD_K","X_STAMPCARD_L","X_STAMPCARD_M","X_STAMPCARD_N","X_STAMPCARD_O","X_STAMPCARD_P","X_KEYPEACHCASTLE","X_KEYKOOPACASTLE","X_SPATICKET_A","X_DLAGONPEARL_RED","X_ORBCOURAGE","X_ORBWISDOM","X_ORBPOWER","X_KEYORB","X_SHELLFISH_BIG","X_KEYKINOKO","X_CANHEART","X_CD_A","X_CD_B","X_CD_C","X_CD_D","X_KNPEYE_A","X_KNPEYE_B","X_KNPEYE_C","X_KNPEYE_D","X_KEYOASIS_A","X_HPMAXUP_LVUP_DRY","X_SUNINCENSE","X_KEYOASIS_B","X_GNERATORHANDLE","X_MASTERKEY","X_BONE","X_SIGNBALL","X_COSTUME_SAM","X_COSTUME_DON","X_COSTUME_KUR","X_THROWINGSTARSET","X_STRAW","X_NORMALPASS","X_PREMIUMPASS","X_CAN_A_OPEN","X_CAN_A","X_MINIPIECE_B","X_MINIPIECE_A","X_TURTLE_BALL_C","X_TURTLE_BALL_D","X_TURTLE_BALL_B","X_TURTLE_BALL_A","X_MANHOLEHANDLE_A","X_DEKUSEED","X_DEKUSEED_DRY","X_FIREFLOWERWITHER","X_KINOKO_DRY"]
+					}
+				},
+				{
+					"name": "Hidden?",
+					"dummy": true,
+					"category": "Key Items",
+					"intArgs": [1],
+					"strArgs": ["bag","key_item_hidden"],
+					"widget":{
+						"type":"bool",
+						"onValue": 1,
+						"offValue": 0
+					}
+				},
+				{
+					"name": "Slot Type",
+					"dummy": true,
+					"category": "Equipped Items",
+					"intArgs": [0],
+					"strArgs": ["equipped","slot_type"],
+					"tooltip": "The type of in-game slot.",
+					"widget":{
+						"type":"list",
+						"listItemNames":["Hammer","Boots","Accessory"],
+						"listItemValues":["hammer","boots","amulet"]
+					}
+				},
+				{
+					"name": "Slot",
+					"dummy": true,
+					"category": "Equipped Items",
+					"intArgs": [0],
+					"strArgs": ["equipped","slot"],
+					"tooltip": "Which in-game slot to configure for the selected slot type.",
+					"widget":{
+						"type":"int",
+						"minValue": 1,
+						"maxValue": 6
+					}
+				},
+				{
+					"name": "Equipped Item Slot",
+					"dummy": true,
+					"category": "Equipped Items",
+					"intArgs": [0],
+					"strArgs": ["equipped","item_slot"],
+					"tooltip": "The associated inventory space to assign to the equipment slot.",
+					"widget":{
+						"type":"int",
+						"minValue": 0,
+						"maxValue": 150
+					}
+				},
+				{
+					"name": "",
+					"category": "Equipped Items",
+					"intArgs": [ ],
+					"strArgs": [ ],
+					"tooltip": "I just make it easier to see the equipped item name.",
+					"widget":{
+						"type":"comment",
+						"comment":"Ignore me"
+					}
+				},
+				{
+					"name": "Equipped Item Name",
+					"dummy": true,
+					"category": "Equipped Items",
+					"intArgs": [0],
+					"strArgs": ["equipped","item_name"],
+					"tooltip": "Displays the name of the item in the associated inventory space.",
+					"widget":{
+						"type":"string",
+						"minLength": 1,
+						"maxLength": 100
+					}
+				},
+				{
+					"name": "Valid Equipment?",
+					"dummy": true,
+					"category": "Equipped Items",
+					"intArgs": [1],
+					"strArgs": ["equipped","valid"],
+					"tooltip": "Displays whether or not the item is a valid selection, and if not, the save file value won't be edited.",
+					"widget": {
+						"type": "bool",
+						"onValue": 1,
+						"offValue": 0
+					}
+				}
+			]
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can PR your own research there if you have some but don't want to build a co
 | [Futaride! Nyanko Daisensou / ふたりで! にゃんこ大戦争](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/01003C300B274000.json)           | bin.lua          | robin5968 | No |
 | [Rune Factory 4 Special (ASIA)](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/010009400DD38000.json)           | rf4s.lua          | Goon and robin5968 | No |
 | [Rune Factory 4 Special (USA)](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/010051D00E3A4000.json)           | rf4s.lua          | Goon and robin5968 | No |
+| [Paper Mario: The Origami King](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Configs/0100A3900C3E2000.json)           | pmtok.lua          | proEndreeper | Yes |
 
 ## Editor Script files
 | Script                            | Requirements            | Author    | Beta   |
@@ -95,6 +96,7 @@ You can PR your own research there if you have some but don't want to build a co
 | [SUPER DRAGON BALL HEROES WORLD MISSION](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/DragonBallHeroes.py) | [lib/python3.5/codecs.py](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/lib/byml.py) | KranK | No |
 | [Gear Club Unlimited](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/GearClubUnlimited.py) | None | haykuro | No |
 | [Rune Factory 4 Special (ASIA)](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/rf4s.lua) | [lib/checksum.lua](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/lib/checksum.lua) | robin5968 | No |
+| [Paper Mario: The Origami King](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/pmtok.lua) | [lib/json.lua](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/lib/json.lua), [lib/checksum.lua](https://github.com/WerWolv/EdiZon_CheatsConfigsAndScripts/blob/master/Scripts/lib/checksum.lua) | proEndreeper | No |
 
 ## Atmosphère Cheats
 

--- a/Scripts/pmtok.lua
+++ b/Scripts/pmtok.lua
@@ -1,0 +1,328 @@
+-- pmtok --
+
+json = require("lib.json")
+checksum = require("lib.checksum")
+
+
+saveFileStringHash = edizon.getSaveFileString()
+saveFileStringHash = saveFileStringHash:gsub('{%s*}', '{"edizon":true}')
+oldHash = saveFileStringHash:sub(saveFileStringHash:len()-7)
+saveFileString = saveFileStringHash:gsub(oldHash,"")
+saveFileBuffer = json.decode(saveFileString)
+
+function getValueFromSaveFile()
+	strArgs = edizon.getStrArgs()
+	intArgs = edizon.getIntArgs()
+
+	item = saveFileBuffer
+	
+	for i, tag in pairs(strArgs) do
+		if type(item) ~= "table" then break end
+	
+		if string.sub(tag, 1, 1) == "\\" then
+			tag = tonumber(tag:sub(2)) + 1
+			
+			if tag == nil then return 0 end
+		end
+	
+		item = item[tag]
+	end
+	if intArgs[1] == 0 then -- Generic
+		return item
+	elseif intArgs[1] == 1 then -- Boolean
+		return item and 1 or 0
+	elseif intArgs[1] == 2 then -- Item Slot
+		if type(item) ~= "table" then return "-2:INVALID_SLOT" end
+		return (item["type"]~=nil and item["type"] or "-1") .. ":" .. (item["itemId"]~=nil and item["itemId"] or "")
+	end
+end
+
+function getStringFromSaveFile()
+	return getValueFromSaveFile()
+end
+
+function string:split(sep)
+   local sep, fields = sep or ":", {}
+   local pattern = string.format("([^%s]*)", sep)
+   self:gsub(pattern, function(c) fields[#fields+1] = c end)
+   return fields
+end
+
+function validateSlot()
+	print("not yet implemented!")
+end
+
+function setValueInSaveFile(value)
+	local items = saveFileBuffer
+	strArgs = edizon.getStrArgs()
+	intArgs = edizon.getIntArgs()
+	
+	local ref = items
+		
+	for i, tag in ipairs(strArgs) do
+		
+		if string.sub(tag, 1, 1) == "\\" then
+			tag = tonumber(tag:sub(2)) + 1
+		end
+		if i == #strArgs then
+			if intArgs[1] == 0 then -- Generic
+				ref[tag] = value
+			elseif intArgs[1] == 1 then -- Boolean
+				ref[tag] = (value == 1)
+			elseif intArgs[1] == 2 then -- Item Slot
+				local splits = value:split(":")
+				local typ = splits[1]~=nil and splits[1] or "-1"
+				local itemId = splits[2]~=nil and splits[2] or ""
+				typ = tonumber(typ)
+				if typ == -1 then -- EMPTY Slot
+					itemId = ""
+				end
+				ref[tag]["type"] = typ
+				ref[tag]["itemId"] = itemId
+			end
+		else 
+			ref = ref[tag]
+		end
+		
+	end
+end
+
+function setStringInSaveFile(value)
+	setValueInSaveFile(value)
+end
+
+local ITEM_LOOKUP_TABLE = {
+  ["0:HAMMER"] = "Hammer",
+  ["0:SILVER_HAMMER"] = "Shiny Hammer",
+  ["0:SUPER_HAMMER"] = "Flashy Hammer",
+  ["0:GREAT_HAMMER"] = "Legendary Hammer",
+  ["0:GOLDEN_HAMMER"] = "Gold Hammer",
+  ["0:THROW_HAMMER"] = "Hurlhammer",
+  ["0:SUPER_THROW_HAMMER"] = "Flashy Hurlhammer",
+  ["0:FIRE_HAMMER"] = "Fire Hammer",
+  ["0:ICE_HAMMER"] = "Ice Hammer",
+  ["1:BOOTS"] = "Boots",
+  ["1:SILVER_BOOTS"] = "Shiny Boots",
+  ["1:SUPER_BOOTS"] = "Flashy Boots",
+  ["1:GREAT_BOOTS"] = "Legendary Boots",
+  ["1:GOLD_BOOTS"] = "Gold Boots",
+  ["1:IRON_BOOTS"] = "Iron Boots",
+  ["1:STEEL_BOOTS"] = "Shiny Iron Boots",
+  ["1:SUPER_IRON_BOOTS"] = "Flashy Iron Boots",
+  ["1:SUPER_STEEL_BOOTS"] = "Legendary Iron Boots",
+  ["4:KINOKO"] = "Mushroom",
+  ["4:SUPER_KINOKO"] = "Shiny Mushroom",
+  ["4:GREAT_KINOKO"] = "Flashy Mushroom",
+  ["4:HEEL_KINOKO"] = "1-Up Mushroom",
+  ["4:FIRE_FLOWER"] = "Fire Flower",
+  ["4:SUPER_FIRE_FLOWER"] = "Shiny Fire Flower",
+  ["4:ICE_FLOWER"] = "Ice Flower",
+  ["4:SUPER_ICE_FLOWER"] = "Shiny Ice Flower",
+  ["4:TAIL"] = "Tail",
+  ["4:SUPER_TAIL"] = "Shiny Tail",
+  ["4:POW_BLOCK"] = "POW Block",
+  ["2:PSV_Battle_DAMAGE1"] = "Guard Plus",
+  ["2:PSV_Battle_DAMAGE2"] = "Silver Guard Plus",
+  ["2:PSV_Battle_DAMAGE3"] = "Gold Guard Plus",
+  ["2:PSV_Puzzle_TIME1"] = "Time Plus",
+  ["2:PSV_Puzzle_TIME2"] = "Silver Time Plus",
+  ["2:PSV_Puzzle_TIME3"] = "Gold Time Plus",
+  ["2:PSV_Sub_PaperVacuum"] = "Confetti Vacuum",
+  ["2:PSV_Sub_FlowerShower"] = "Petal Bag",
+  ["2:PSV_Sub_MembersCard1"] = "Membership Card",
+  ["2:PSV_Sub_MembersCard2"] = "Silver Membership Card",
+  ["2:PSV_Sub_MembersCard3"] = "Gold Membership Card",
+  ["2:PSV_Battle_HP1"] = "Heart Plus",
+  ["2:PSV_Battle_HP2"] = "Silver Heart Plus",
+  ["2:PSV_Battle_HP3"] = "Gold Heart Plus",
+  ["2:PSV_Sub_KinopioAlarm"] = "Toad Alert",
+  ["2:PSV_Sub_TreasureAlarm"] = "Treasure Alert",
+  ["2:PSV_Sub_HideBlockAlarm"] = "Hidden Block Alert",
+  ["4:IC_KINOPIO_RS"] = "Toad Radar",
+  ["4:IC_WHISTLE"] = "Boot Whistle",
+  ["2:PSV_Sub_BattleParty"] = "Ally Tambourine",
+  ["4:IC_LATENCY"] = "Lamination Suit",
+  ["2:PSV_Sub_Pedometer"] = "Coin Step Counter",
+  ["2:PSV_Sub_MarioSound"] = "Retro Soundbox",
+  ["4:IC_SECRET_BLOCK_RS"] = "Hidden Block Unhider",
+  ["-1:"] = "Nothing"
+}
+
+item_slot = 1
+key_item_slot = 1
+
+local dummy_equipped = {
+	slot_type = "hammer",
+	slot = 1,
+	item_slot = -1
+}
+
+local DUMMY_TYPES = {
+	hammer = {
+		max_slot = 4,
+		item_type = 0
+	},
+	boots = {
+		max_slot = 4,
+		item_type = 1
+	},
+	amulet = {
+		max_slot = 6,
+		item_type = 2
+	}
+}
+
+function getDummyValue()
+	local items = saveFileBuffer
+	if items["Pouch"]==nil 
+		or items["Pouch"]["equipment"]==nil 
+		or items["Pouch"]["equipment"]["bag"]==nil 
+		or items["Pouch"]["equipment"]["hammer"]==nil
+		or items["Pouch"]["equipment"]["boots"]==nil
+		or items["Pouch"]["equipment"]["amulet"]==nil
+		or items["Pouch"]["key_item"]==nil then
+			return 0
+		end
+	strArgs = edizon.getStrArgs()
+	intArgs = edizon.getIntArgs()
+
+	if strArgs[1] == "bag" then
+		local item = items["Pouch"]["equipment"]["bag"][tostring(item_slot - 1)]
+		local keyitem = items["Pouch"]["key_item"][tostring(key_item_slot - 1)]
+
+		if strArgs[2] == "item_slot" then
+			return item_slot
+		elseif strArgs[2] == "item_descriptor" then
+			return item["type"] .. ":" .. item["itemId"]
+		elseif strArgs[2] == "item_damage" then
+			return item["usedEndurance"]
+		elseif strArgs[2] == "item_durability" then
+			return item["usedBreakRate"]
+		elseif strArgs[2] == "item_count" then
+			return item["stackCount"]
+		elseif strArgs[2] == "key_item_slot" then
+			return key_item_slot
+		elseif strArgs[2] == "key_item_name" then
+			return keyitem["id"]
+		elseif strArgs[2] == "key_item_hidden" then
+			return keyitem["removed"] and 1 or 0
+		end
+	elseif strArgs[1] == "equipped" then
+		local dummy_nil = (dummy_equipped.item_slot == 0)
+
+		if dummy_equipped.item_slot < 0 then
+			dummy_equipped.item_slot = items["Pouch"]["equipment"][dummy_equipped.slot_type][dummy_equipped.slot] + 1
+		end
+
+		local dummy_item = items["Pouch"]["equipment"]["bag"][tostring(dummy_equipped.item_slot - 1)] or {type=-1,itemId=""}
+
+		if dummy_equipped[strArgs[2]]~=nil then
+			return dummy_equipped[strArgs[2]]
+		elseif strArgs[2] == "item_name" then
+			if dummy_nil then return "None" end
+			local id = dummy_item["type"]..":"..dummy_item["itemId"]
+			return ITEM_LOOKUP_TABLE[id]
+		elseif strArgs[2] == "valid" then
+			if dummy_nil then return 1 end
+			return dummy_item["type"]==DUMMY_TYPES[dummy_equipped.slot_type]["item_type"] and 1 or 0
+		end
+	end
+end
+
+
+function getDummyString()
+	return getDummyValue()
+end
+
+function setDummyValue(value)
+	local items = saveFileBuffer
+	if items["Pouch"]==nil 
+		or items["Pouch"]["equipment"]==nil 
+		or items["Pouch"]["equipment"]["bag"]==nil
+		or items["Pouch"]["equipment"]["hammer"]==nil
+		or items["Pouch"]["equipment"]["boots"]==nil
+		or items["Pouch"]["equipment"]["amulet"]==nil 
+		or items["Pouch"]["key_item"]==nil then
+			return 0
+		end
+	strArgs = edizon.getStrArgs()
+	intArgs = edizon.getIntArgs()
+		
+	if strArgs[1] == "bag" then
+		local item = items["Pouch"]["equipment"]["bag"][tostring(item_slot - 1)]
+		local keyitem = items["Pouch"]["key_item"][tostring(key_item_slot - 1)]
+		if strArgs[2] == "item_slot" then
+			item_slot = value
+		elseif strArgs[2] == "item_descriptor" then
+			local splits = value:split(":")
+			local typ = splits[1]~=nil and splits[1] or "-1"
+			local itemId = splits[2]~=nil and splits[2] or ""
+			typ = tonumber(typ)
+			if typ == -1 then -- EMPTY Slot
+				itemId = ""
+			end
+			item["type"] = typ
+			item["itemId"] = itemId
+		elseif strArgs[2] == "item_damage" then
+			item["usedEndurance"] = value
+		elseif strArgs[2] == "item_durability" then
+			item["usedBreakRate"] = value
+		elseif strArgs[2] == "item_count" then
+			item["stackCount"] = value
+		elseif strArgs[2] == "key_item_slot" then
+			key_item_slot = value
+		elseif strArgs[2] == "key_item_name" then
+			keyitem["id"] = value
+		elseif strArgs[2] == "key_item_hidden" then
+			keyitem["removed"] = (value==1)
+		end
+	elseif strArgs[1] == "equipped" then
+		if strArgs[2] == "slot_type" and DUMMY_TYPES[value]~=nil then
+			dummy_equipped.slot_type = value
+			dummy_equipped.slot = 1
+			dummy_equipped.item_slot = items["Pouch"]["equipment"][value][1] + 1
+		elseif strArgs[2] == "slot" then
+			if value <= DUMMY_TYPES[dummy_equipped.slot_type]["max_slot"] then
+				dummy_equipped.slot = value
+				dummy_equipped.item_slot = items["Pouch"]["equipment"][dummy_equipped.slot_type][value] + 1
+			end
+		elseif strArgs[2] == "item_slot" then
+			dummy_equipped.item_slot = value
+			local dummy_item = items["Pouch"]["bag"][tostring(value - 1)]
+			if (dummy_item~=nil and dummy_item["type"]==DUMMY_TYPES[dummy_equipped.slot_type]["item_type"]) or dummy_equipped.item_slot == 0 then
+				items["Pouch"]["equipment"][dummy_equipped.slot_type][dummy_equipped.slot] = dummy_equipped.item_slot - 1
+			end
+		end
+	else
+		print("Unknown Dummy Hierarchy! '" .. strArgs[1] .. "'")
+	end
+end
+
+function setDummyString(value)
+	setDummyValue(value)
+end
+
+local function convertToTable(s)
+	t = {}
+	
+	for i = 1, #s do
+		t[i] = string.byte(s:sub(i, i))
+	end
+	
+	return t
+end
+
+function getModifiedSaveFile()
+	encoded = json.encode(saveFileBuffer)
+	
+	encoded = encoded:gsub('{"edizon":true}', '{}')
+
+	crc = checksum.crc32(encoded)
+
+	encoded = encoded .. string.format("%08x",crc)
+	
+	convertedTable = {}
+	convertedTable = convertToTable(encoded)
+				
+	return convertedTable
+end


### PR DESCRIPTION
Paper Mario: The Origami King Save Editor, supports changing what items are equipped, what items are in the inventory, what "Useful Items" are in the inventory, along with whether or not they are hidden. Also includes ability to change various save file records including the number of game overs, the number of toad points, along other stats. In addition lets you change the number of coins you have, your current hp and max hp, your confetti total and maximum confetti. Finally includes the ability to mark that you've received any of the Bibliofolds. 